### PR TITLE
Allow python-igraph 0.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -877,7 +877,7 @@ options =  dict(
 
   provides = ['louvain'],
   python_requires=">=3.7",
-  install_requires = ['igraph >= 0.10.0,< 0.11'],
+  install_requires = ['igraph >= 0.10.0,< 0.12'],
   platforms="ALL",
   keywords=[
     'graph',


### PR DESCRIPTION
as it is still based on C/igraph 0.10, therefore compatible